### PR TITLE
test againg go 1.5

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: bradrydzewski/go:1.3
+image: clever/drone-go:1.5
 notify:
   email:
     recipients:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+SHELL := /bin/bash
+PKG := github.com/Clever/mgotail
+GOLINT := $(GOPATH)/bin/golint
+.PHONY: $(PKG) test
+GOVERSION := $(shell go version | grep 1.5)
+ifeq "$(GOVERSION)" ""
+  $(error must be running Go version 1.5)
+endif
+
+test: $(PKG)
+
+$(GOLINT):
+	go get github.com/golang/lint/golint
+
+$(PKG): $(GOLINT)
+	gofmt -w=true $(GOPATH)/src/$@/*.go
+	$(GOLINT) $(GOPATH)/src/$@/*.go
+	go get -d -t $(PKG)
+	go vet $@
+	go test -v $@

--- a/tail.go
+++ b/tail.go
@@ -1,9 +1,10 @@
 package mgotail
 
 import (
+	"time"
+
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"time"
 )
 
 // OplogQuery describes a query you'd like to perform on the oplog.
@@ -15,13 +16,13 @@ type OplogQuery struct {
 
 // Oplog is a deserialization of the fields present in an oplog entry.
 type Oplog struct {
-	Timestamp    bson.MongoTimestamp "ts"
-	HistoryID    int64               "h"
-	MongoVersion int                 "v"
-	Operation    string              "op"
-	Namespace    string              "ns"
-	Object       bson.M              "o"
-	QueryObject  bson.M              "o2"
+	Timestamp    bson.MongoTimestamp `bson:"ts"`
+	HistoryID    int64               `bson:"h"`
+	MongoVersion int                 `bson:"v"`
+	Operation    string              `bson:"op"`
+	Namespace    string              `bson:"ns"`
+	Object       bson.M              `bson:"o"`
+	QueryObject  bson.M              `bson:"o2"`
 }
 
 // LastTime gets the timestamp of the last operation in the oplog.

--- a/test_drone.sh
+++ b/test_drone.sh
@@ -4,5 +4,4 @@ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
 sudo apt-get update
 sudo apt-get install -y mongodb-10gen=2.4.12
-go get -d -t
-go test
+make test


### PR DESCRIPTION
Needed to increase timeout on oplog query to get this to work

This timeout controls how long the cursor waits for the next result before timing out. For some reason the oplog entries were coming in very slowly, despite the writes happening in a tight loop.